### PR TITLE
fix: map the event date and time not the createat

### DIFF
--- a/src/services/senior/mappers/clocking-event-by-active-user-query-mapper.ts
+++ b/src/services/senior/mappers/clocking-event-by-active-user-query-mapper.ts
@@ -3,5 +3,7 @@ import { ClockingEventByActiveUserQueryResponse } from '../dtos/clocking-event-b
 export const mapClockingEventByActiveUserQuery = (
   data: ClockingEventByActiveUserQueryResponse
 ): string[] => {
-  return data.result.map((clocking) => clocking.createdAt)
+  return data.result.map(
+    (clocking) => clocking.dateEvent + ' ' + clocking.timeEvent
+  )
 }


### PR DESCRIPTION
Changed to pick the event date and time and not the create at, because when you have an event that doesn't sync right away it's going to have the created_at different from the event.